### PR TITLE
fix: ISO-8601 error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
                 "changelog": "Initial release",
                 "targetAbi": "10.9.0.0",
                 "sourceUrl": "https://github.com/EnderRobber101/JellyTube/releases/download/Initial/JellyTube.zip",
-                "timestamp": "2024-08-22 10:24:58",
+                "timestamp": "2024-08-22T10:24:58",
                 "version": "1.0.0.0"
             },
             {
@@ -21,7 +21,7 @@
                 "changelog": "release 2 with embedded subtitles",
                 "targetAbi": "10.9.0.0",
                 "sourceUrl": "https://github.com/EnderRobber101/JellyTube/releases/download/release/JellyTube.zip",
-                "timestamp": "2024-09-27 10:24:58",
+                "timestamp": "2024-09-27T10:24:58",
                 "version": "2.0.0.0"
             }
         ]


### PR DESCRIPTION
Currently, navigating to the plugin via the catalog throws this error:

```
Error: Couldn't parse ISO 8601 date string '2024-08-22 10:24:58'
    at o ([REDACTED]/web/main.jellyfin.bundle.js?f1238435f421c71ad785:2:301722)
    at [REDACTED]/web/plugins-plugin.3420d67af1391b068d1a.chunk.js:1:9626
    at Array.map (<anonymous>)
    at en ([REDACTED]/web/plugins-plugin.3420d67af1391b068d1a.chunk.js:1:9435)
    at hu ([REDACTED]/web/node_modules.react-dom.bundle.js?f1238435f421c71ad785:2:60311)
    at xi ([REDACTED]/web/node_modules.react-dom.bundle.js?f1238435f421c71ad785:2:119252)
    at bs ([REDACTED]/web/node_modules.react-dom.bundle.js?f1238435f421c71ad785:2:108504)
    at vs ([REDACTED]/web/node_modules.react-dom.bundle.js?f1238435f421c71ad785:2:108432)
    at gs ([REDACTED]/web/node_modules.react-dom.bundle.js?f1238435f421c71ad785:2:108295)
    at as ([REDACTED]/web/node_modules.react-dom.bundle.js?f1238435f421c71ad785:2:105130)
```

I've changed the timestamps to comply with ISO 8601, hopefully this fixes it.